### PR TITLE
Disabled 'no-unresolved' rule

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     "lines-between-class-members": 0,
     "react/destructuring-assignment": 0,
     "react/jsx-wrap-multilines": 0,
+    "import/no-unresolved": 0,
 
     // WARN
     "no-console": ["warn", { allow: ["assert"] }],


### PR DESCRIPTION
`import/no-unresolved` only checks the default module resolution method. Since we'll have absolute imports configured, this rule will report a ton of false positives. Webpack is smart enough to catch unresolved imports, anywya.