### PR TITLE
Enable namespaces in TS.

### DIFF
--- a/packages/tslint-config/tslint.json
+++ b/packages/tslint-config/tslint.json
@@ -28,6 +28,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
+    "no-namespace": false,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,


### PR DESCRIPTION
This is turned on by `tslint:recommended`, but now that it is supported by babel we can use it safely.

See @Akuukis comment here https://github.com/stellar/js-stellar-sdk/pull/375#issuecomment-513401179 