### PR TITLE
Remove no-use-before-declare.

### DIFF
--- a/packages/tslint-config/tslint.json
+++ b/packages/tslint-config/tslint.json
@@ -33,7 +33,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "object-literal-sort-keys": false,
     "one-line": [
       true,


### PR DESCRIPTION
This rule is only useful if we allow `var` which we don't via `no-var-keyword` in `tslint:recommended`.

It was also generating a warning but we can remove it and use the default value from `tslint:recommended` which is `false`.

From https://palantir.github.io/tslint/rules/no-use-before-declare/

> Since most modern TypeScript doesn’t use var, this rule is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions.

Before:

```bash
$ ~/stellar/js-stellar-sdk $ npx gulp lint:src
[14:47:17] Using gulpfile ~/stellar/js-stellar-sdk/gulpfile.js
[14:47:17] Starting 'lint:src'...
Warning: The 'no-use-before-declare' rule requires type information.
[14:47:18] Finished 'lint:src' after 679 ms
```

After:
```bash
$ ~/stellar/js-stellar-sdk $ npx gulp lint:src
[14:47:49] Using gulpfile ~/stellar/js-stellar-sdk/gulpfile.js
[14:47:49] Starting 'lint:src'...
[14:47:50] Finished 'lint:src' after 658 ms
```