### PR TITLE
Disable object prototype rule

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     "linebreak-style": 0,
     "no-underscore-dangle": 0,
     "no-use-before-define": 0,
+    "no-prototype-builtins": 0,
     "prefer-destructuring": 0,
     "react/forbid-prop-types": 0,
     "react/jsx-indent": 0,


### PR DESCRIPTION
The lint rule says,

> You may want to turn this rule off if your code only touches objects with hardcoded keys, and you will never use an object that shadows an Object.prototype method or which does not inherit from Object.prototype.

That sounds like code we expect to write, and I strongly dislike the `Object.prototype.hasOwnProperty.call(foo, "bar")` recommendation it makes