### PR TITLE
Ensure `curly` rule uses `all`.

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -159,7 +159,7 @@ module.exports = {
     "comma-dangle": "error",
     complexity: "off",
     "constructor-super": "error",
-    curly: "error",
+    curly: ["error", "all"],
     "default-case": "error",
     "eol-last": "off",
     eqeqeq: ["error", "smart"],


### PR DESCRIPTION
Although we had `curly` enabled, it was still allowing one line ifs.