### PR TITLE
Update prettier version, and use the new(er) `bracketSameLine` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "husky": "^3.0.8",
     "lerna": "^3.16.4",
     "lint-staged": "^9.4.1",
-    "prettier": "^1.18.2"
+    "prettier": "^3.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ]
   },
   "devDependencies": {
-    "@stellar/prettier-config": "^1.1.1",
+    "@stellar/prettier-config": "^1.2.0",
     "husky": "^3.0.8",
     "lerna": "^3.16.4",
     "lint-staged": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ]
   },
   "devDependencies": {
-    "@stellar/prettier-config": "^1.0.1",
+    "@stellar/prettier-config": "^1.1.1",
     "husky": "^3.0.8",
     "lerna": "^3.16.4",
     "lint-staged": "^9.4.1",

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-First, install the package, and make sure you've upgraded Prettier to >= 1.17.0:
+First, install the package, and make sure you've upgraded Prettier to >= 3.2.5:
 
 ```
 yarn add --dev @stellar/prettier-config prettier

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/stellar/product-conventions/issues"
   },
   "peerDependencies": {
-    "prettier": ">=1.17.0"
+    "prettier": "^3.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/prettier-config",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Stellar Development Foundation's default prettier config",
   "author": "Morley Zhi <morley@stellar.org>",
   "homepage": "https://github.com/stellar/product-conventions#readme",

--- a/packages/prettier-config/prettier.config.js
+++ b/packages/prettier-config/prettier.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   arrowParens: "always",
   bracketSpacing: true,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   printWidth: 80,
   proseWrap: "always",
   semi: true,

--- a/packages/prettier-config/yarn.lock
+++ b/packages/prettier-config/yarn.lock
@@ -2,7 +2,3 @@
 # yarn lockfile v1
 
 
-prettier@^1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,10 +4161,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This attempts to fix the `jsxBracketSameLine` deprecation error I see when working in the `stellar-docs` and `soroban-docs` repos.

## What I Did

I updated the prettier version to `3.2.5`, which is the most recent stable release at time of writing. I wasn't exactly sure how the package(s) use the various `package.json` files in this repository, so I updated prettier in the "main" package file, and in the prettier-config package file:

```bash
yarn add prettier@latest --dev
cd packages/prettier-config
yarn add prettier@latest --peer # not sure why it's peer, but that's where it was in package.json... 🤷🏻 
```

I also tested this package locally by adding it as the `@stellar/prettier-config` package in one of my docs repositories. I don't know much about npm package testing/publishing, or if there's a more "fool-proof" way to test this out, but it seemed to work as expected in this (very simple) test.

## What I'm Still Unsure About

- I used prettier `v3.2.5` just because that's what `prettier@latest` resolved to. That _feels like_ it's a pretty big leap from the previous `v1.17.0`, though? Would there be a reason to use a different version here? Are the version strings in both `./package.json` and `./packages/prettier-config/package.json` files meant to match?
- I didn't modify the `@stellar/prettier-config` package version number. Don't know how big of a "scope" this change introduces. Someone else could probably make that decision better than I can.

I'd love some feedback, since this is the first PR I've really ever made against a "utility" package like this. I'm sure I've bungled something along the way 🤣 

Refs: #43 