### PR TITLE
Make an intermediate release that upgrades prettier to v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "husky": "^3.0.8",
     "lerna": "^3.16.4",
     "lint-staged": "^9.4.1",
-    "prettier": "^1.18.2"
+    "prettier": "^2.8.8"
   }
 }

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-First, install the package, and make sure you've upgraded Prettier to >= 1.17.0:
+First, install the package, and make sure you've upgraded Prettier to >= 2.8.8:
 
 ```
 yarn add --dev @stellar/prettier-config prettier

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/prettier-config",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Stellar Development Foundation's default prettier config",
   "author": "Morley Zhi <morley@stellar.org>",
   "homepage": "https://github.com/stellar/product-conventions#readme",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/stellar/product-conventions/issues"
   },
   "peerDependencies": {
-    "prettier": ">=1.17.0"
+    "prettier": "^2.8.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prettier-config/yarn.lock
+++ b/packages/prettier-config/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-prettier@^1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,10 +4161,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As discussed in Slack, this PR will upgrade to the latest `2.x` version of Prettier, rather than jumping all the way from `v1.x` to `v3.x`

Refs: #43, #45