### PR TITLE
Add dependabot.yml for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories: 
+      - "/"
+      - "/packages/eslint-config"
+      - "/packages/prettier-config"
+      - "/packages/tsconfig"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "02:00"
+    open-pull-requests-limit: 2
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"
+      major:
+        applies-to: version-updates
+        update-types:
+        - "major"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "02:00"
+    open-pull-requests-limit: 2
+    groups:
+      all-actions:
+        applies-to: version-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
### What

Adding base config for `dependabot.yml`, which enables automatic PRs for [dependency version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) through Dependabot. This base config sets version updates to run on a `weekly` schedule, groups PRs for version updates according to `major` vs `minor/patch` updates, and sets max PRs that Dependabot can create for version updates  per package-ecosystem. 
But if you would like, several config options can be added to `dependabot.yml` as per [configuration-options-for-the-dependabot.yml-file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) to customize version updates, such as:

- Group PRs for version updates by [different criteria](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)
- Set `dependency-type` option in [allow option](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) to `all` for enabling version updates for both direct and indirect dependencies (as well as prod and dev dependencies). By default, PRs for only updating direct prod+dev dependencies versions are created.
- Set [reviewers](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) for Dependabot version updates PRs
- Etc.

Also, automatic PRs for [security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) through Dependabot are already enabled through a global setting. PRs for security updates will be grouped as much as possible across directories and per ecosystem through the global setting ([grouping-dependabot-security-updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#grouping-dependabot-security-updates-into-a-single-pull-request)). But `dependabot.yml` can also be used for more granular security updates settings in addition to version updates (some of the options in `dependabot.yml` are shared across security and version updates), such as:

- Grouping security updates according to custom criteria: [overriding-the-default-behavior-with-a-configuration-file](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file) 
- Only allowing automatic PRs for security updates for certain dependencies by configuring [allow directive](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) to a certain value such as `production, development, direct, indirect`. By default, security updates are applied to all dependencies (direct, indirect, production, development).
- Etc.

### Why

To enable using the latest package versions, and provide a way to customize Dependabot security updates PRs.

### Known limitations

N/A